### PR TITLE
CMParts: add one finger swipe up from home gesture string

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -609,6 +609,7 @@
 
     <string name="touchscreen_gesture_two_finger_down_swipe_title">Swipe down with two fingers</string>
     <string name="touchscreen_gesture_one_finger_up_swipe_title">Swipe up with one finger</string>
+    <string name="touchscreen_gesture_one_finger_up_swipe_home_title">Swipe up from the home button</string>
     <string name="touchscreen_gesture_one_finger_down_swipe_title">Swipe down with one finger</string>
     <string name="touchscreen_gesture_one_finger_left_swipe_title">Swipe left with one finger</string>
     <string name="touchscreen_gesture_one_finger_right_swipe_title">Swipe right with one finger</string>


### PR DESCRIPTION
Modern Samsungs support swiping up from the home button as a touchscreen
gesture. "Swipe up with one finger" is not specific enough: the gesture
only works if you start it in the bottom ~1/5th of the touchscreen.

Change-Id: I7e4c257f04388579b5682208fecb79e63c13e770