### PR TITLE
CMParts: Network Traffic [3/3]

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2012-2015 The CyanogenMod Project
+     Copyright (C) 2017-2018 The LineageOS Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -332,4 +333,34 @@
         <item>300</item>
         <item>600</item>
     </string-array>
+
+    <!-- Network Traffic -->
+    <string-array name="network_traffic_mode_entries" translatable="false">
+        <item>@string/network_traffic_mode_disable</item>
+        <item>@string/network_traffic_mode_up</item>
+        <item>@string/network_traffic_mode_down</item>
+        <item>@string/network_traffic_mode_all</item>
+    </string-array>
+
+    <string-array name="network_traffic_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
+    <string-array name="network_traffic_units_entries" translatable="false">
+        <item>@string/network_traffic_units_kilobits</item>
+        <item>@string/network_traffic_units_megabits</item>
+        <item>@string/network_traffic_units_kilobytes</item>
+        <item>@string/network_traffic_units_megabytes</item>
+    </string-array>
+
+    <string-array name="network_traffic_units_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 	Copyright (C) 2015 The CyanogenMod Project
-	          (C) 2017 The LineageOS Project
+	Copyright (C) 2017-2018 The LineageOS Project
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -491,6 +491,24 @@
     <!-- Status bar - icon blacklist -->
     <string name="status_bar_icons_title">Status bar icons</string>
     <string name="status_bar_icons_summary">Control which status bar icons are shown</string>
+
+    <!-- Status bar - Network Traffic -->
+    <string name="network_traffic_settings_title">Network traffic monitor</string>
+    <string name="network_traffic_settings_summary">Show current network traffic levels in the status bar</string>
+    <string name="network_traffic_mode_title">Display mode</string>
+    <string name="network_traffic_mode_disable">Disabled</string>
+    <string name="network_traffic_mode_up">Upload only</string>
+    <string name="network_traffic_mode_down">Download only</string>
+    <string name="network_traffic_mode_all">Upload and download</string>
+    <string name="network_traffic_autohide">Auto hide</string>
+    <string name="network_traffic_autohide_summary">Hide the traffic monitor when there is no activity</string>
+    <string name="network_traffic_units_title">Traffic measurement units</string>
+    <string name="network_traffic_units_kilobits">Kilobits per second (kb/s)</string>
+    <string name="network_traffic_units_megabits">Megabits per second (Mb/s)</string>
+    <string name="network_traffic_units_kilobytes">Kilobytes per second (kB/s)</string>
+    <string name="network_traffic_units_megabytes">Megabytes per second (MB/s)</string>
+    <string name="network_traffic_show_units">Show units</string>
+    <string name="network_traffic_show_units_summary">Whether to show traffic measurement units in the statusbar</string>
 
     <!-- Protected apps -->
     <string name="protected_apps_manager_title">Protected apps</string>

--- a/res/xml/network_traffic_settings.xml
+++ b/res/xml/network_traffic_settings.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2017-2018 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
+
+    <DropDownPreference
+        android:key="network_traffic_mode"
+        android:title="@string/network_traffic_mode_title"
+        android:entries="@array/network_traffic_mode_entries"
+        android:entryValues="@array/network_traffic_mode_values"
+        android:summary="%s"
+        android:persistent="false" />
+
+    <cyanogenmod.preference.CMSecureSettingSwitchPreference
+        android:key="network_traffic_autohide"
+        android:title="@string/network_traffic_autohide"
+        android:summary="@string/network_traffic_autohide_summary"
+        android:defaultValue="false" />
+
+    <DropDownPreference
+        android:key="network_traffic_units"
+        android:title="@string/network_traffic_units_title"
+        android:entries="@array/network_traffic_units_entries"
+        android:entryValues="@array/network_traffic_units_values"
+        android:summary="%s"
+        android:persistent="false" />
+
+    <cyanogenmod.preference.CMSecureSettingSwitchPreference
+        android:key="network_traffic_show_units"
+        android:title="@string/network_traffic_show_units"
+        android:summary="@string/network_traffic_show_units_summary"
+        android:defaultValue="true" />
+
+</PreferenceScreen>

--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
      Copyright (C) 2014-2016 The CyanogenMod Project
+     Copyright (C) 2017-2018 The LineageOS Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -26,6 +27,12 @@
         android:entries="@array/status_bar_quick_qs_pulldown_entries"
         android:entryValues="@array/status_bar_quick_qs_pulldown_values"
         android:defaultValue="0" />
+
+    <PreferenceScreen
+        android:fragment="org.cyanogenmod.cmparts.statusbar.NetworkTrafficSettings"
+        android:key="network_traffic_settings"
+        android:title="@string/network_traffic_settings_title"
+        android:summary="@string/network_traffic_settings_summary" />
 
     <PreferenceCategory
         android:title="@string/status_bar_icons_title">

--- a/src/org/cyanogenmod/cmparts/statusbar/NetworkTrafficSettings.java
+++ b/src/org/cyanogenmod/cmparts/statusbar/NetworkTrafficSettings.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017-2018 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cyanogenmod.cmparts.statusbar;
+
+import android.content.ContentResolver;
+import android.os.Bundle;
+import android.support.v7.preference.DropDownPreference;
+import android.support.v7.preference.Preference;
+
+import cyanogenmod.preference.CMSecureSettingSwitchPreference;
+import cyanogenmod.providers.CMSettings;
+import org.cyanogenmod.cmparts.R;
+import org.cyanogenmod.cmparts.SettingsPreferenceFragment;
+
+
+public class NetworkTrafficSettings extends SettingsPreferenceFragment
+        implements Preference.OnPreferenceChangeListener  {
+
+    private static final String TAG = "NetworkTrafficSettings";
+
+    private DropDownPreference mNetTrafficMode;
+    private CMSecureSettingSwitchPreference mNetTrafficAutohide;
+    private DropDownPreference mNetTrafficUnits;
+    private CMSecureSettingSwitchPreference mNetTrafficShowUnits;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.network_traffic_settings);
+        final ContentResolver resolver = getActivity().getContentResolver();
+
+        mNetTrafficMode = (DropDownPreference)
+                findPreference(CMSettings.Secure.NETWORK_TRAFFIC_MODE);
+        mNetTrafficMode.setOnPreferenceChangeListener(this);
+        int mode = CMSettings.Secure.getInt(resolver,
+                CMSettings.Secure.NETWORK_TRAFFIC_MODE, 0);
+        mNetTrafficMode.setValue(String.valueOf(mode));
+
+        mNetTrafficAutohide = (CMSecureSettingSwitchPreference)
+                findPreference(CMSettings.Secure.NETWORK_TRAFFIC_AUTOHIDE);
+        mNetTrafficAutohide.setOnPreferenceChangeListener(this);
+
+        mNetTrafficUnits = (DropDownPreference)
+                findPreference(CMSettings.Secure.NETWORK_TRAFFIC_UNITS);
+        mNetTrafficUnits.setOnPreferenceChangeListener(this);
+        int units = CMSettings.Secure.getInt(resolver,
+                CMSettings.Secure.NETWORK_TRAFFIC_UNITS, /* Mbps */ 1);
+        mNetTrafficUnits.setValue(String.valueOf(units));
+
+        mNetTrafficShowUnits = (CMSecureSettingSwitchPreference)
+                findPreference(CMSettings.Secure.NETWORK_TRAFFIC_SHOW_UNITS);
+        mNetTrafficShowUnits.setOnPreferenceChangeListener(this);
+
+        updateEnabledStates(mode);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference == mNetTrafficMode) {
+            int mode = Integer.valueOf((String) newValue);
+            CMSettings.Secure.putInt(getActivity().getContentResolver(),
+                    CMSettings.Secure.NETWORK_TRAFFIC_MODE, mode);
+            updateEnabledStates(mode);
+        } else if (preference == mNetTrafficUnits) {
+            int units = Integer.valueOf((String) newValue);
+            CMSettings.Secure.putInt(getActivity().getContentResolver(),
+                    CMSettings.Secure.NETWORK_TRAFFIC_UNITS, units);
+        }
+        return true;
+    }
+
+    private void updateEnabledStates(int mode) {
+        final boolean enabled = mode != 0;
+        mNetTrafficAutohide.setEnabled(enabled);
+        mNetTrafficUnits.setEnabled(enabled);
+        mNetTrafficShowUnits.setEnabled(enabled);
+    }
+}


### PR DESCRIPTION
*) Backport to cm-14.1 (achalmgucker)

*) Adapted to Lineage SDK (bgcngm).

*) Replace autohide threshold selection with the option
   of kb/s, Mb/s (and kB/s or MB/s) (sam3000).

*) Add an option for the user to choose whether or not
   the units are displayed in the statusbar (sam3000).

Change-Id: Idbc0d984177cad284f092339e9b1dc18f8aca9e2